### PR TITLE
Remove broken comment

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "compilerOptions": {
-    /* Visit https:
-
     "target": "es2021" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */,
     "module": "commonjs",
 


### PR DESCRIPTION
This fixes the Vite error about `tsconfig.json` by removing a broken comment.