### PR TITLE
Remove require.main block

### DIFF
--- a/lib/crowdnode.js
+++ b/lib/crowdnode.js
@@ -523,20 +523,6 @@ function parseAddr(prefix, html) {
   return hotwallet;
 }
 
-if (require.main === module) {
-  (async function main() {
-    //@ts-ignore
-    await CrowdNode.init({
-      //@ts-ignore
-      baseUrl: CrowdNode.main.baseUrl,
-      insightBaseUrl: "https://insight.dash.org",
-    });
-    console.info(CrowdNode);
-  })().catch(function (err) {
-    console.error(err);
-  });
-}
-
 function toDuff(dash) {
   return Math.round(parseFloat(dash) * DUFFS);
 }


### PR DESCRIPTION
Same fix from #45 but to the `browser` branch instead of `browser3`
This line [dashhive/crowdnode.js/blob/main/lib/crowdnode.js#L521](https://github.com/dashhive/crowdnode.js/blob/main/lib/crowdnode.js#L521) `if (require.main === module) {` causes an issue with building the vite app into a static site, didnt seem to affect the dev mode, but the dist version gets a `Uncaught ReferenceError: require is not defined` error when loading in the browser.

Removing this block as a potential fix. Per side convo, might want to be added to a test. This is not creating the test. 😇 