### PR TITLE
Switch `@dashincubator/blocktx` to `dashtx` & upgrade dep versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,68 +1,94 @@
 {
   "name": "crowdnode",
   "version": "1.8.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crowdnode",
       "version": "1.8.0",
       "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@dashincubator/base58check": "^1.3.1",
-        "@dashincubator/blocktx": "^0.9.0-2",
-        "@dashincubator/ripemd160": "^2.3.0",
-        "@dashincubator/secp256k1": "^1.7.1-1",
-        "dashsight": "^1.3.0-0"
-      },
       "bin": {
         "crowdnode": "bin/crowdnode.js"
       },
+      "devDependencies": {
+        "@types/node": "^20.14.12"
+      },
       "optionalDependencies": {
+        "@dashincubator/base58check": "^1.4.1",
+        "@dashincubator/ripemd160": "^3.0.0",
+        "@dashincubator/secp256k1": "dashhive/secp256k1.js#sync-with-upstream",
         "@root/request": "^1.9.2",
-        "dotenv": "^16.0.1",
+        "dashhd": "dashhive/DashHD.js#ref-secp256k1-2.1.0-compat",
+        "dashkeys": "^1.1.4",
+        "dashsight": "^1.6.1",
+        "dashtx": "^0.16.0",
+        "dotenv": "^16.4.5",
         "qrcode-svg": "^1.1.0",
-        "tough-cookie": "^4.0.0",
-        "ws": "^8.8.0"
+        "tough-cookie": "^4.1.4",
+        "ws": "^8.18.0"
       }
     },
     "node_modules/@dashincubator/base58check": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@dashincubator/base58check/-/base58check-1.3.1.tgz",
-      "integrity": "sha512-v2vYOwsTmbfaADJUg+0Vsw61/P5XtdDnjZtImDIC5DePIA/2lT9V+00nR5GsKfwc40WQ02tFlN+xoFt9cx+P7A==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@dashincubator/base58check/-/base58check-1.4.1.tgz",
+      "integrity": "sha512-JSAO+viM3pVgM93XSBAUhLvK18BlRIsmYU4eGuyrj1lz3Xa1oplSel94oG0SI5d2qTxdy0NfGT3vEFbiKpfj5Q==",
+      "license": "SEE LICENSE IN LICENSE",
+      "optional": true,
       "bin": {
         "base58check": "bin/base58check.js"
       }
     },
-    "node_modules/@dashincubator/blocktx": {
-      "version": "0.9.0-2",
-      "resolved": "https://registry.npmjs.org/@dashincubator/blocktx/-/blocktx-0.9.0-2.tgz",
-      "integrity": "sha512-g6IQxx/nuwsl3Dxzq61bE/UM8t/qQOnnnpF6BzPReHFd4XudQvQ+WcMXRJbrCQWj4yoR5SOCCBZ6IG7As3aVOg==",
-      "bin": {
-        "blocktx-inspect": "bin/inspect.js"
-      }
-    },
     "node_modules/@dashincubator/ripemd160": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dashincubator/ripemd160/-/ripemd160-2.3.0.tgz",
-      "integrity": "sha512-SfaUhvXti0Ut6ZhlAwurrRAG56phxqWozj72Hixx/v3LSQj1/wjkgTuDaexil672CzLD+RRWoPgp41BSM+DJJA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dashincubator/ripemd160/-/ripemd160-3.0.0.tgz",
+      "integrity": "sha512-EbdXcceP2mW76NchCKp8UYNbZgWkLuV4Mbi30G82xRED32ljJzXsKaaVdzU0oVo2fVzPRXF1GhSF6Lq9beTVvA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@dashincubator/secp256k1": {
-      "version": "1.7.1-1",
-      "resolved": "https://registry.npmjs.org/@dashincubator/secp256k1/-/secp256k1-1.7.1-1.tgz",
-      "integrity": "sha512-zkCfHPiIBWkSHojMEVBGNi9y9vX0NHGxkwO5zdZVlhbiqpWGOPbFRbUIwbEFdlnx4tS2x8w8InNzl36qVYWsGg=="
+      "version": "2.1.0",
+      "resolved": "git+ssh://git@github.com/dashhive/secp256k1.js.git#d587c1a24ca7d5c47f7cb519ca70a54920da3245",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@root/request": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@root/request/-/request-1.9.2.tgz",
-      "integrity": "sha512-wVaL9yVV9oDR9UNbPZa20qgY+4Ch6YN8JUkaE4el/uuS5dmhD8Lusm/ku8qJVNtmQA56XLzEDCRS6/vfpiHK2A=="
+      "integrity": "sha512-wVaL9yVV9oDR9UNbPZa20qgY+4Ch6YN8JUkaE4el/uuS5dmhD8Lusm/ku8qJVNtmQA56XLzEDCRS6/vfpiHK2A==",
+      "optional": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
+      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/dashhd": {
+      "version": "3.3.3",
+      "resolved": "git+ssh://git@github.com/dashhive/DashHD.js.git#92cf91acf5633ed2ebed3b4f39d0d0f1d830679e",
+      "license": "SEE LICENSE IN LICENSE",
+      "optional": true
+    },
+    "node_modules/dashkeys": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/dashkeys/-/dashkeys-1.1.4.tgz",
+      "integrity": "sha512-y62hg+r8V56gqUfvnyNqCmQ0MvA/wGmRPWfuKFKDCZY02dvWkhCD0zBRVpBGPjfk+T2gWKbkcrHOCrb2RXZ9cw==",
+      "license": "SEE LICENSE IN LICENSE",
+      "optional": true
     },
     "node_modules/dashsight": {
-      "version": "1.3.0-0",
-      "resolved": "https://registry.npmjs.org/dashsight/-/dashsight-1.3.0-0.tgz",
-      "integrity": "sha512-KR2Vj6Ts94FLRFr0A3xqa4PAf3R9njrN5k7IHzbzDZjohb+cG3+11e48W0Dvt6CQGC4+yToRnUvlrBmGdpU5TQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/dashsight/-/dashsight-1.6.1.tgz",
+      "integrity": "sha512-FCGeFO9NIic+Gzr9DwLTLY19xripHMbd3dHIrt+tXULHPaoBYs2P1GARqKuvYMWR0m+QXOcODs8Czlih6wXNYg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "optional": true,
       "dependencies": {
-        "@root/request": "^1.9.2"
+        "dashtx": "^0.9.0-3"
       },
       "bin": {
         "dashsight-balance": "bin/balance.js",
@@ -75,13 +101,37 @@
         "dotenv": "^16.0.1"
       }
     },
+    "node_modules/dashsight/node_modules/dashtx": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/dashtx/-/dashtx-0.9.0.tgz",
+      "integrity": "sha512-DDbH5vPChUpOrYMOoM+6g/Iy99KqG4nkJ6f8TphnGibzAY7mitjMgtFSc62YzbZdoPGYeSPm8N4jmz+Mbwm7Eg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "optional": true,
+      "bin": {
+        "dashtx-inspect": "bin/inspect.js"
+      }
+    },
+    "node_modules/dashtx": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/dashtx/-/dashtx-0.16.0.tgz",
+      "integrity": "sha512-YyLYzq8OPBLAU2DYmQEk0KXqAZkpQcNYXmZEBHJUjeRNEU4q9xDVK1Tqj3AUekQ2E71Ccyn1xp07zdU9XVD7WA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "optional": true,
+      "bin": {
+        "dashtx-inspect": "bin/inspect.js"
+      }
+    },
     "node_modules/dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
       "optional": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/psl": {
@@ -108,40 +158,76 @@
         "qrcode-svg": "bin/qrcode-svg.js"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -151,90 +237,6 @@
           "optional": true
         }
       }
-    }
-  },
-  "dependencies": {
-    "@dashincubator/base58check": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@dashincubator/base58check/-/base58check-1.3.1.tgz",
-      "integrity": "sha512-v2vYOwsTmbfaADJUg+0Vsw61/P5XtdDnjZtImDIC5DePIA/2lT9V+00nR5GsKfwc40WQ02tFlN+xoFt9cx+P7A=="
-    },
-    "@dashincubator/blocktx": {
-      "version": "0.9.0-2",
-      "resolved": "https://registry.npmjs.org/@dashincubator/blocktx/-/blocktx-0.9.0-2.tgz",
-      "integrity": "sha512-g6IQxx/nuwsl3Dxzq61bE/UM8t/qQOnnnpF6BzPReHFd4XudQvQ+WcMXRJbrCQWj4yoR5SOCCBZ6IG7As3aVOg=="
-    },
-    "@dashincubator/ripemd160": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dashincubator/ripemd160/-/ripemd160-2.3.0.tgz",
-      "integrity": "sha512-SfaUhvXti0Ut6ZhlAwurrRAG56phxqWozj72Hixx/v3LSQj1/wjkgTuDaexil672CzLD+RRWoPgp41BSM+DJJA=="
-    },
-    "@dashincubator/secp256k1": {
-      "version": "1.7.1-1",
-      "resolved": "https://registry.npmjs.org/@dashincubator/secp256k1/-/secp256k1-1.7.1-1.tgz",
-      "integrity": "sha512-zkCfHPiIBWkSHojMEVBGNi9y9vX0NHGxkwO5zdZVlhbiqpWGOPbFRbUIwbEFdlnx4tS2x8w8InNzl36qVYWsGg=="
-    },
-    "@root/request": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@root/request/-/request-1.9.2.tgz",
-      "integrity": "sha512-wVaL9yVV9oDR9UNbPZa20qgY+4Ch6YN8JUkaE4el/uuS5dmhD8Lusm/ku8qJVNtmQA56XLzEDCRS6/vfpiHK2A=="
-    },
-    "dashsight": {
-      "version": "1.3.0-0",
-      "resolved": "https://registry.npmjs.org/dashsight/-/dashsight-1.3.0-0.tgz",
-      "integrity": "sha512-KR2Vj6Ts94FLRFr0A3xqa4PAf3R9njrN5k7IHzbzDZjohb+cG3+11e48W0Dvt6CQGC4+yToRnUvlrBmGdpU5TQ==",
-      "requires": {
-        "@root/request": "^1.9.2",
-        "dotenv": "^16.0.1"
-      }
-    },
-    "dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
-      "optional": true
-    },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "optional": true
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "optional": true
-    },
-    "qrcode-svg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/qrcode-svg/-/qrcode-svg-1.1.0.tgz",
-      "integrity": "sha512-XyQCIXux1zEIA3NPb0AeR8UMYvXZzWEhgdBgBjH9gO7M48H9uoHzviNz8pXw3UzrAcxRRRn9gxHewAVK7bn9qw==",
-      "optional": true
-    },
-    "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-      "optional": true,
-      "requires": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
-      }
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "optional": true
-    },
-    "ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
-      "optional": true,
-      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "./index.js",
   "browser": {
     "index.js": "crowdnode.js",
-    "./lib/dashcore.js": "./lib/browser-dashcore.js",
     "./lib/request.js": "./shims/request-browser.js",
     "./shims/crypto-node.js": "./shims/crypto-browser.js",
     "crypto": false
@@ -21,6 +20,7 @@
     "bin",
     "crowdnode.js",
     "dashapi.js",
+    "dashcore-lit.js",
     "index.js",
     "lib"
   ],
@@ -36,23 +36,30 @@
     "Staking"
   ],
   "author": "AJ ONeal <aj@therootcompany.com> (https://therootcompany.com)",
+  "contributors": [
+    "AJ ONeal <aj@therootcompany.com> (https://therootcompany.com)",
+    "jojobyte <byte@jojo.io> (https://jojo.io/)"
+  ],
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/dashhive/crowdnode.js/issues"
   },
   "homepage": "https://github.com/dashhive/crowdnode.js#readme",
-  "dependencies": {
-    "@dashincubator/base58check": "^1.3.1",
-    "@dashincubator/blocktx": "^0.9.0-2",
-    "@dashincubator/ripemd160": "^2.3.0",
-    "@dashincubator/secp256k1": "^1.7.1-1",
-    "dashsight": "^1.3.0-0"
-  },
   "optionalDependencies": {
+    "@dashincubator/base58check": "^1.4.1",
+    "@dashincubator/ripemd160": "^3.0.0",
+    "@dashincubator/secp256k1": "dashhive/secp256k1.js#sync-with-upstream",
     "@root/request": "^1.9.2",
-    "dotenv": "^16.0.1",
+    "dashhd": "dashhive/DashHD.js#ref-secp256k1-2.1.0-compat",
+    "dashkeys": "^1.1.4",
+    "dashsight": "^1.6.1",
+    "dashtx": "^0.16.0",
+    "dotenv": "^16.4.5",
     "qrcode-svg": "^1.1.0",
-    "tough-cookie": "^4.0.0",
-    "ws": "^8.8.0"
+    "tough-cookie": "^4.1.4",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.12"
   }
 }


### PR DESCRIPTION
This PR does a few things:

- Upgrades all dependencies to their latest version
- Changes all `dependencies` into `optionalDependencies` to support `globalThis`/`window` exports
  - Attempts to use `Base58Check`, `DashTx`, `RIPEMD160`, & `Secp256k1` from `globalThis`/`window` before requiring deps
- Adds `@types/node` to `devDependencies`
- Upgrades `@dashincubator/blocktx` to `dashtx@^0.16.0`

`dashtx@^0.18.1` is currently not used due to some breaking API changes in the package.